### PR TITLE
Add trade forcing + adds myself to authors

### DIFF
--- a/src/main/java/me/senseiwells/essentialclient/clientscript/definitions/MerchantScreenDef.java
+++ b/src/main/java/me/senseiwells/essentialclient/clientscript/definitions/MerchantScreenDef.java
@@ -2,6 +2,7 @@ package me.senseiwells.essentialclient.clientscript.definitions;
 
 import me.senseiwells.arucas.api.docs.ClassDoc;
 import me.senseiwells.arucas.api.docs.FunctionDoc;
+import me.senseiwells.arucas.builtin.BooleanDef;
 import me.senseiwells.arucas.builtin.NumberDef;
 import me.senseiwells.arucas.classes.CreatableDefinition;
 import me.senseiwells.arucas.classes.PrimitiveDefinition;
@@ -64,8 +65,8 @@ public class MerchantScreenDef extends CreatableDefinition<MerchantScreen> {
 			MemberFunction.of("selectTrade", 1, this::selectTrade),
 			MemberFunction.of("clearTrade", this::clearTrade),
 			MemberFunction.of("isTradeSelected", this::isTradeSelected),
-			MemberFunction.of("tradeSelected", this::tradeSelected),
-			MemberFunction.of("tradeSelectedAndThrow", this::tradeSelectedAndThrow)
+			MemberFunction.arb("tradeSelected", this::tradeSelected),
+			MemberFunction.arb("tradeSelectedAndThrow", this::tradeSelectedAndThrow)
 		);
 	}
 
@@ -234,12 +235,14 @@ public class MerchantScreenDef extends CreatableDefinition<MerchantScreen> {
 		name = "tradeSelected",
 		desc = {
 			"This trades the currently selected trade.",
+			"This function accepts optional boolean to simulate click action even if screen is not synced or filled.",
 			"You must be inside the merchant GUI or an error will be thrown"
 		},
 		examples = "screen.tradeSelected();"
 	)
 	private Void tradeSelected(Arguments arguments) {
-		ensureMainThread("tradeSelected", arguments.getInterpreter(), () -> InventoryUtils.tradeSelectedRecipe(false));
+		boolean force = arguments.skip().hasNext() ? arguments.nextPrimitive(BooleanDef.class) : false;
+		ensureMainThread("tradeSelected", arguments.getInterpreter(), () -> InventoryUtils.tradeSelectedRecipe(false, force));
 		return null;
 	}
 
@@ -247,12 +250,14 @@ public class MerchantScreenDef extends CreatableDefinition<MerchantScreen> {
 		name = "tradeSelectedAndThrow",
 		desc = {
 			"This trades the currently selected trade and throws the items that were traded.",
+			"This function accepts optional boolean to simulate click action even if screen is not synced or filled.",
 			"You must be inside the merchant GUI or an error will be thrown"
 		},
 		examples = "screen.tradeSelectedAndThrow();"
 	)
 	private Void tradeSelectedAndThrow(Arguments arguments) {
-		ensureMainThread("tradeSelectedAndThrow", arguments.getInterpreter(), () -> InventoryUtils.tradeSelectedRecipe(true));
+		boolean force = arguments.skip().hasNext() ? arguments.nextPrimitive(BooleanDef.class) : false;
+		ensureMainThread("tradeSelectedAndThrow", arguments.getInterpreter(), () -> InventoryUtils.tradeSelectedRecipe(true, force));
 		return null;
 	}
 

--- a/src/main/java/me/senseiwells/essentialclient/clientscript/definitions/PlayerDef.java
+++ b/src/main/java/me/senseiwells/essentialclient/clientscript/definitions/PlayerDef.java
@@ -110,6 +110,7 @@ public class PlayerDef extends CreatableDefinition<ClientPlayerEntity> {
 			MemberFunction.of("messageActionBar", 1, this::messageActionBar),
 			MemberFunction.of("showTitle", 1, this::showTitle),
 			MemberFunction.of("openInventory", this::openInventory),
+			MemberFunction.of("selectTrade", 1, this::selectTrade, "Use <MerchantScreen>.selectTrade(int) for normal uses"),
 			MemberFunction.of("openScreen", 1, this::openScreen),
 			MemberFunction.of("closeScreen", this::closeScreen),
 			MemberFunction.of("setWalking", 1, this::setWalking),
@@ -236,6 +237,20 @@ public class PlayerDef extends CreatableDefinition<ClientPlayerEntity> {
 	)
 	private Void say(Arguments arguments) {
 		EssentialUtils.sendChatMessage(arguments.skip().next().toString(arguments.getInterpreter()));
+		return null;
+	}
+
+	@FunctionDoc(
+		name = "selectTrade",
+		desc = "This allows you to player send trade select packet, maybe while screen is being opened.",
+		params = {NUMBER, "index", "the trade index to send"},
+		examples = "player.selectTrade(0);"
+	)
+	private Void selectTrade(Arguments arguments) {
+		int index = arguments.skip().nextPrimitive(NumberDef.class).intValue();
+		ClientScriptUtils.ensureMainThread("selectTradeUnsafe", arguments.getInterpreter(), () -> {
+			InventoryUtils.selectTradeUnsafe(index);
+		});
 		return null;
 	}
 

--- a/src/main/java/me/senseiwells/essentialclient/utils/inventory/InventoryUtils.java
+++ b/src/main/java/me/senseiwells/essentialclient/utils/inventory/InventoryUtils.java
@@ -635,6 +635,10 @@ public class InventoryUtils {
 		EssentialUtils.getNetworkHandler().sendPacket(new SelectMerchantTradeC2SPacket(index));
 	}
 
+	public static void selectTradeUnsafe(int index) {
+		EssentialUtils.getNetworkHandler().sendPacket(new SelectMerchantTradeC2SPacket(index));
+	}
+
 	public static void tradeSelectedRecipe(boolean drop) {
 		MerchantScreenHandler screenHandler = checkScreen();
 		Slot tradeSlot = screenHandler.getSlot(2);

--- a/src/main/java/me/senseiwells/essentialclient/utils/inventory/InventoryUtils.java
+++ b/src/main/java/me/senseiwells/essentialclient/utils/inventory/InventoryUtils.java
@@ -648,6 +648,20 @@ public class InventoryUtils {
 		shiftClickSlot(screenHandler, 2);
 	}
 
+	public static void tradeSelectedRecipe(boolean drop, boolean force) {
+		if (!force) {
+			tradeSelectedRecipe(drop);
+			return;
+		}
+		MerchantScreenHandler screenHandler = checkScreen();
+		Slot tradeSlot = screenHandler.getSlot(2);
+		if (drop) {
+			getInteractionManager().clickSlot(screenHandler.syncId, 2, 1, SlotActionType.THROW, getPlayer());
+			return;
+		}
+		shiftClickSlot(screenHandler, 2);
+	}
+
 	public static void clearTradeInputSlot(MerchantScreenHandler handler) {
 		ClientPlayerEntity player = EssentialUtils.getPlayer();
 		Slot slot = handler.getSlot(0);

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -12,7 +12,8 @@
     "Crec0",
     "Pixeils",
     "HardCoded",
-    "BvngeeCord"
+    "BvngeeCord",
+    "AngelBottomless"
   ],
   "contact": {
     "homepage": "https://github.com/senseiwells/EssentialClient"


### PR DESCRIPTION
this situation explains the need for this
```
sleep(1500);
screen = player.getCurrentScreen();
screen.selectTrade(0);
screen.tradeSelected(false);
```
It won't trade, because screen is not synced. However since we know server will have something in their screen, we can safely click output slot even if we don't see something.
It enables much faster trading. We can do same thing for "selecting Trade" because selecting trade packet does not require any screen handler reference. 

It also means trading can be 'instant' - you can omit waiting process.
