### PR TITLE
[1.19.x] Update Minecraft Wiki links to new domain

### DIFF
--- a/src/main/java/me/senseiwells/essentialclient/clientscript/values/BlockValue.java
+++ b/src/main/java/me/senseiwells/essentialclient/clientscript/values/BlockValue.java
@@ -311,7 +311,7 @@ public class BlockValue extends GenericValue<BlockState> implements MaterialLike
 			desc = {
 				"This gets the properties of the Block",
 				"You can find a list of all block properties",
-				"[here](https://minecraft.fandom.com/wiki/Java_Edition_data_values#Block_states)"
+				"[here](https://minecraft.wiki/w/Java_Edition_data_values#Block_states)"
 			},
 			returns = {MAP, "the properties of the Block, may be empty if there are no properties"},
 			example = "block.getBlockProperties();"

--- a/src/main/java/me/senseiwells/essentialclient/clientscript/values/LivingEntityValue.java
+++ b/src/main/java/me/senseiwells/essentialclient/clientscript/values/LivingEntityValue.java
@@ -63,7 +63,7 @@ public class LivingEntityValue<T extends LivingEntity> extends EntityValue<T> {
 			desc = {
 				"This gets the LivingEntity's status effects, you can find",
 				"a list of all the ids of the status effects",
-				"[here](https://minecraft.fandom.com/wiki/Java_Edition_data_values#Effects)"
+				"[here](https://minecraft.wiki/w/Java_Edition_data_values#Effects)"
 			},
 			returns = {LIST, "a list of status effects, may be empty"},
 			example = "livingEntity.getStatusEffects();"

--- a/src/main/java/me/senseiwells/essentialclient/clientscript/values/MinecraftClientValue.java
+++ b/src/main/java/me/senseiwells/essentialclient/clientscript/values/MinecraftClientValue.java
@@ -700,7 +700,7 @@ public class MinecraftClientValue extends GenericValue<MinecraftClient> {
 			name = "playSound",
 			desc = {
 				"This plays the given sound with the given volume and pitch around the player",
-				"sound id's can be found [here](https://minecraft.fandom.com/wiki/Sounds.json#Sound_events)"
+				"sound id's can be found [here](https://minecraft.wiki/w/Sounds.json#Sound_events)"
 			},
 			params = {
 				STRING, "soundId", "the sound id you want to play",

--- a/src/main/java/me/senseiwells/essentialclient/clientscript/values/TextValue.java
+++ b/src/main/java/me/senseiwells/essentialclient/clientscript/values/TextValue.java
@@ -216,7 +216,7 @@ public class TextValue extends GenericValue<MutableText> {
 			name = "format",
 			desc = {
 				"This allows you to add a formatting to a text instance",
-				"A list of formatting names can be found [here](https://minecraft.fandom.com/wiki/Formatting_codes)"
+				"A list of formatting names can be found [here](https://minecraft.wiki/w/Formatting_codes)"
 			},
 			params = {STRING, "formatting", "the name of the formatting"},
 			returns = {TEXT, "the text instance with the formatting added"},

--- a/src/main/java/me/senseiwells/essentialclient/clientscript/values/WorldValue.java
+++ b/src/main/java/me/senseiwells/essentialclient/clientscript/values/WorldValue.java
@@ -316,7 +316,7 @@ public class WorldValue extends GenericValue<ClientWorld> {
 			name = "getTimeOfDay",
 			desc = {
 				"This will get the time of day of the world",
-				"info on the time of day [here](https://minecraft.fandom.com/wiki/Daylight_cycle)"
+				"info on the time of day [here](https://minecraft.wiki/w/Daylight_cycle)"
 			},
 			returns = {NUMBER, "the time of day of the world, between 0 and 24000"},
 			example = "world.getTimeOfDay();"
@@ -329,7 +329,7 @@ public class WorldValue extends GenericValue<ClientWorld> {
 			name = "renderParticle",
 			desc = {
 				"This will render a particle in the world, you can find a list of all",
-				"the particle ids [here](https://minecraft.fandom.com/wiki/Java_Edition_data_values#Particles)"
+				"the particle ids [here](https://minecraft.wiki/w/Java_Edition_data_values#Particles)"
 			},
 			params = {
 				STRING, "particleId", "the id of the particle",
@@ -359,7 +359,7 @@ public class WorldValue extends GenericValue<ClientWorld> {
 			name = "renderParticle",
 			desc = {
 				"This will render a particle in the world, you can find a list of all",
-				"the particle ids [here](https://minecraft.fandom.com/wiki/Java_Edition_data_values#Particles)"
+				"the particle ids [here](https://minecraft.wiki/w/Java_Edition_data_values#Particles)"
 			},
 			params = {
 				STRING, "particleId", "the id of the particle",
@@ -393,7 +393,7 @@ public class WorldValue extends GenericValue<ClientWorld> {
 			name = "renderParticle",
 			desc = {
 				"This will render a particle in the world with a velocity, you can find a list of all",
-				"the particle ids [here](https://minecraft.fandom.com/wiki/Java_Edition_data_values#Particles)"
+				"the particle ids [here](https://minecraft.wiki/w/Java_Edition_data_values#Particles)"
 			},
 			params = {
 				STRING, "particleId", "the id of the particle",


### PR DESCRIPTION
The Minecraft Fandom wiki has been forked to a new domain: minecraft.wiki. Learn more here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. This PR updates all URLs accordingly.